### PR TITLE
Update to hashbrown 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ crossbeam-channel = "0.3.9"
 ethsign = "0.7.3"
 futures="0.3"
 generic-array = { version = "0.13.2", features = ["serde"] }
-hashbrown = "0.7"
+hashbrown = "0.9"
 hex = "0.4.2"
 log = "0.4"
 openssl = "0.10"

--- a/kad/src/service.rs
+++ b/kad/src/service.rs
@@ -118,7 +118,7 @@ where
         let table = &mut self.table;
 
         self.requests
-            .drain_filter(|_, (_, _, created_at)| now - *created_at < ttl)
+            .drain_filter(|_, (_, _, created_at)| ttl <= now - *created_at)
             .for_each(|(_, (_, key, _))| {
                 table.remove(&key);
             });

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -175,7 +175,7 @@ impl ConnectionManager {
     pub fn prune_pending(&mut self, older_than: Duration) {
         let now = Instant::now();
         self.pending
-            .drain_filter(|_, trigger| older_than < now - trigger.created_at)
+            .drain_filter(|_, trigger| now - trigger.created_at <= older_than)
             .for_each(|(addr, mut trigger)| {
                 if trigger.is_pending() {
                     log::debug!(


### PR DESCRIPTION
The behavior of the `HashMap::drain_filter` method has changed in this release.  For details, see: https://github.com/rust-lang/hashbrown/issues/186